### PR TITLE
Update WASI Core URL and title

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [WASI GitHub Repo](https://github.com/webassembly/WASI)
 - [Mozilla Announcement](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/)
 - [WASI SDK](https://github.com/CraneStation/wasi-sdk)
-- [WASI Core API](https://github.com/WebAssembly/WASI/blob/master/design/WASI-core.md)
+- [WASI Preview API (Previously known as WASI-Core)](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs/wasi_unstable_preview1.md)
 - [WASI CG Meetings](https://github.com/WebAssembly/WASI/tree/master/meetings)
 
 


### PR DESCRIPTION
WASI Core was renamed to deemphasize the word "Core", and the link to the document has changed as well. This change includes the latest link to the document.

- [x] I've read [CONTRIBUTING.md](https://github.com/wasmerio/awesome-wasi/blob/master/CONTRIBUTING.md).
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).